### PR TITLE
feat(dart): add getter methods and bump version to 0.1.49

### DIFF
--- a/runagent-dart/lib/src/client/runagent_client.dart
+++ b/runagent-dart/lib/src/client/runagent_client.dart
@@ -448,6 +448,12 @@ class RunAgentClient {
   /// Get any extra params supplied during initialization
   Map<String, dynamic>? getExtraParams() => extraParams;
 
+  /// Get the user ID used for persistent memory, if any.
+  String? getUserId() => userId;
+
+  /// Check if persistent memory is enabled for this client.
+  bool getPersistentMemory() => persistentMemory;
+
   /// Check if using local deployment
   bool isLocal() => local;
 

--- a/runagent-dart/lib/src/utils/constants.dart
+++ b/runagent-dart/lib/src/utils/constants.dart
@@ -33,6 +33,6 @@ class RunAgentConstants {
   static const String envTimeout = 'RUNAGENT_TIMEOUT';
   
   /// User agent string
-  static String userAgent() => 'runagent-dart/0.1.0';
+  static String userAgent() => 'runagent-dart/0.1.49';
 }
 

--- a/runagent-dart/pubspec.yaml
+++ b/runagent-dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: runagent
 description: RunAgent SDK for Dart/Flutter - Interact with deployed AI agents via REST and WebSocket
-version: 0.1.43
+version: 0.1.49
 homepage: https://github.com/runagent-dev/runagent-dart
 
 environment:


### PR DESCRIPTION
## Summary
- Add `getUserId()` and `getPersistentMemory()` getter methods to `RunAgentClient`, matching the pattern of existing getters (`getAgentId()`, `getEntrypointTag()`, `getExtraParams()`)
- Bump version from `0.1.43` to `0.1.49` to align with Python/TS/Rust SDKs
- Update user-agent string from `runagent-dart/0.1.0` to `runagent-dart/0.1.49`

## Test plan
- [ ] Verify `getUserId()` returns the configured user ID
- [ ] Verify `getPersistentMemory()` returns the configured persistent memory flag
- [ ] Verify user-agent header reflects `0.1.49` in outgoing requests
- [ ] Run `dart analyze` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public methods to query user ID and persistent memory settings.

* **Chores**
  * Version updated to 0.1.49.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->