### PR TITLE
feat(ts): add persistent_memory and user_id support

### DIFF
--- a/runagent-ts/src/client/index.ts
+++ b/runagent-ts/src/client/index.ts
@@ -73,6 +73,12 @@ const getEnvVar = (name: string): string | undefined => {
   return undefined;
 };
 
+const parseEnvBool = (name: string): boolean | undefined => {
+  const val = getEnvVar(name);
+  if (val === undefined) return undefined;
+  return val.toLowerCase() === 'true' || val === '1';
+};
+
 export class RunAgentClient {
   private serializer: CoreSerializer;
   private local: boolean;
@@ -108,7 +114,7 @@ export class RunAgentClient {
     this.baseUrl = config.baseUrl ?? getEnvVar(BASE_URL_ENV);
     this.baseSocketUrl = config.baseSocketUrl;
     this._userId = config.userId ?? getEnvVar('RUNAGENT_USER_ID');
-    this._persistentMemory = config.persistentMemory ?? false;
+    this._persistentMemory = config.persistentMemory ?? parseEnvBool('RUNAGENT_PERSISTENT_MEMORY') ?? false;
 
     if (!this.baseUrl && !this.local) {
       this.baseUrl = DEFAULT_REMOTE_BASE_URL;

--- a/runagent-ts/src/client/index.ts
+++ b/runagent-ts/src/client/index.ts
@@ -91,6 +91,8 @@ export class RunAgentClient {
   private timeoutSeconds: number;
   private extraParams?: Record<string, unknown>;
   private enableRegistry: boolean;
+  private _userId?: string;
+  private _persistentMemory: boolean;
 
   constructor(config: RunAgentConfig) {
     this.serializer = new CoreSerializer();
@@ -105,6 +107,8 @@ export class RunAgentClient {
     this.apiKey = config.apiKey ?? getEnvVar(API_KEY_ENV);
     this.baseUrl = config.baseUrl ?? getEnvVar(BASE_URL_ENV);
     this.baseSocketUrl = config.baseSocketUrl;
+    this._userId = config.userId ?? getEnvVar('RUNAGENT_USER_ID');
+    this._persistentMemory = config.persistentMemory ?? false;
 
     if (!this.baseUrl && !this.local) {
       this.baseUrl = DEFAULT_REMOTE_BASE_URL;
@@ -354,7 +358,9 @@ export class RunAgentClient {
         inputArgs: [],
         inputKwargs,
         timeoutSeconds: this.timeoutSeconds,
-      }
+      },
+      this._userId,
+      this._persistentMemory
     );
 
     if (response.success !== false) {
@@ -405,7 +411,9 @@ export class RunAgentClient {
         inputArgs: [],
         inputKwargs,
         timeoutSeconds: this.timeoutSeconds,
-      }
+      },
+      this._userId,
+      this._persistentMemory
     );
   }
 
@@ -427,6 +435,14 @@ export class RunAgentClient {
 
   getExtraParams(): Record<string, unknown> | undefined {
     return this.extraParams;
+  }
+
+  getUserId(): string | undefined {
+    return this._userId;
+  }
+
+  getPersistentMemory(): boolean {
+    return this._persistentMemory;
   }
 
   /**

--- a/runagent-ts/src/rest/index.ts
+++ b/runagent-ts/src/rest/index.ts
@@ -70,7 +70,7 @@ export class RestClient {
       if (userId) {
         requestData.user_id = userId;
       }
-      if (persistentMemory) {
+      if (persistentMemory !== undefined) {
         requestData.persistent_memory = persistentMemory;
       }
 

--- a/runagent-ts/src/rest/index.ts
+++ b/runagent-ts/src/rest/index.ts
@@ -49,7 +49,9 @@ export class RestClient {
   async runAgent(
     agentId: string,
     entrypointTag: string,
-    options: RunAgentOptions = {}
+    options: RunAgentOptions = {},
+    userId?: string,
+    persistentMemory?: boolean
   ): Promise<ApiResponse> {
     const {
       inputArgs = [],
@@ -57,20 +59,29 @@ export class RestClient {
       timeoutSeconds = this.defaultTimeoutSeconds,
     } = options;
 
-      const requestData = {
+      const requestData: Record<string, unknown> = {
       entrypoint_tag: entrypointTag,
           input_args: inputArgs,
           input_kwargs: inputKwargs,
       timeout_seconds: timeoutSeconds,
       async_execution: false,
-      } as JsonValue;
+      };
+
+      if (userId) {
+        requestData.user_id = userId;
+      }
+      if (persistentMemory) {
+        requestData.persistent_memory = persistentMemory;
+      }
+
+      const typedRequestData = requestData as JsonValue;
       
     const timeoutMs = timeoutSeconds * 1000 + 10_000; // Add buffer similar to Python SDK
 
       try {
         const response = await this.http.post(
         `/agents/${agentId}/run`,
-          requestData,
+          typedRequestData,
         { timeout: timeoutMs }
       );
 

--- a/runagent-ts/src/types/index.ts
+++ b/runagent-ts/src/types/index.ts
@@ -11,6 +11,8 @@ export interface RunAgentConfig {
   timeoutSeconds?: number;
   extraParams?: Record<string, unknown>;
   enableRegistry?: boolean;
+  userId?: string;
+  persistentMemory?: boolean;
 }
   
 export interface ApiResponse<T = JsonValue> {
@@ -61,6 +63,8 @@ export interface ExecutionRequest {
   input_kwargs: Record<string, unknown>;
   timeout_seconds?: number;
   async_execution?: boolean;
+  user_id?: string;
+  persistent_memory?: boolean;
 }
   
 export interface SerializedObject {

--- a/runagent-ts/src/websocket/base.ts
+++ b/runagent-ts/src/websocket/base.ts
@@ -92,7 +92,7 @@ export abstract class BaseWebSocketClient {
       if (userId) {
         request.user_id = userId;
       }
-      if (persistentMemory) {
+      if (persistentMemory !== undefined) {
         request.persistent_memory = persistentMemory;
       }
 

--- a/runagent-ts/src/websocket/base.ts
+++ b/runagent-ts/src/websocket/base.ts
@@ -57,7 +57,9 @@ export abstract class BaseWebSocketClient {
   async *runStream(
     agentId: string,
     entrypointTag: string,
-    options: RunStreamOptions = {}
+    options: RunStreamOptions = {},
+    userId?: string,
+    persistentMemory?: boolean
   ): AsyncGenerator<unknown, void, unknown> {
     const { inputArgs = null, inputKwargs = null, timeoutSeconds } = options;
     const endpoint = `${this.baseSocketUrl}/agents/${agentId}/run-stream`;
@@ -86,6 +88,13 @@ export abstract class BaseWebSocketClient {
         timeout_seconds: timeoutSeconds ?? this.timeoutSeconds,
         async_execution: false,
       };
+
+      if (userId) {
+        request.user_id = userId;
+      }
+      if (persistentMemory) {
+        request.persistent_memory = persistentMemory;
+      }
 
       this.sendMessage(websocket, JSON.stringify(request));
 


### PR DESCRIPTION
## Summary
- Add `userId` and `persistentMemory` to `RunAgentConfig` interface
- Add `user_id` and `persistent_memory` to `ExecutionRequest` interface
- Store fields in `RunAgentClient` with env var fallback (`RUNAGENT_USER_ID`)
- Add `getUserId()` and `getPersistentMemory()` getter methods
- Conditionally include both fields in REST and WebSocket request payloads (only when set)

Brings the TypeScript SDK in line with the Rust and C# reference implementations per `sdk_checklist.md`.

## Test plan
- [ ] Verify `getUserId()` returns configured user ID (explicit or env var)
- [ ] Verify `getPersistentMemory()` returns configured flag (defaults to `false`)
- [ ] Verify `user_id` appears in REST POST body only when set
- [ ] Verify `persistent_memory` appears in REST POST body only when `true`
- [ ] Verify both fields appear in WebSocket request payload when set
- [ ] Verify fields are omitted when not configured
- [ ] Run `npm run build` to confirm TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User identity tracking: Configure and retrieve user IDs for agent execution and streaming, allowing runs to be associated with a specific user.
  * Persistent memory control: Enable or disable persistent memory on a per-execution basis to control state retention across runs.
  * Unified API support: These options are supported for both REST and WebSocket-based agent execution and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->