### PR TITLE
feat(python): add getter methods for SDK field access

### DIFF
--- a/runagent/client/client.py
+++ b/runagent/client/client.py
@@ -22,7 +22,7 @@ class RunAgentExecutionError(Exception):
 
 class RunAgentClient:
 
-    def __init__(self, agent_id: str, entrypoint_tag: str, local: bool = True, host: str = None, port: int = None, user_id: str = None, persistent_memory: bool = False):
+    def __init__(self, agent_id: str, entrypoint_tag: str, local: bool = True, host: str = None, port: int = None, user_id: str = None, persistent_memory: bool = False, extra_params: dict = None):
         self.sdk = RunAgentSDK()
         self.serializer = CoreSerializer()
         self.local = local
@@ -35,6 +35,7 @@ class RunAgentClient:
         # Persistent storage settings (set at client level)
         self.user_id = user_id
         self.persistent_memory = persistent_memory
+        self.extra_params = extra_params
         
         # FIXED: Detect if this is a streaming entrypoint
         self.is_streaming = entrypoint_tag.endswith("_stream")
@@ -207,7 +208,7 @@ class RunAgentClient:
 
     def get_extra_params(self) -> dict | None:
         """Get any extra params supplied during initialization."""
-        return getattr(self, 'extra_params', None)
+        return self.extra_params
 
     def _run_stream(self, *input_args, **input_kwargs):
         """Legacy method - use run_stream instead"""

--- a/runagent/client/client.py
+++ b/runagent/client/client.py
@@ -189,6 +189,26 @@ class RunAgentClient:
 
         return _iterator()
 
+    def get_user_id(self) -> str | None:
+        """Get the user ID used for persistent memory, if any."""
+        return self.user_id
+
+    def get_persistent_memory(self) -> bool:
+        """Check if persistent memory is enabled for this client."""
+        return self.persistent_memory
+
+    def get_agent_id(self) -> str:
+        """Get the agent ID this client is configured for."""
+        return self.agent_id
+
+    def get_entrypoint_tag(self) -> str:
+        """Get the entrypoint tag this client is configured for."""
+        return self.entrypoint_tag
+
+    def get_extra_params(self) -> dict | None:
+        """Get any extra params supplied during initialization."""
+        return getattr(self, 'extra_params', None)
+
     def _run_stream(self, *input_args, **input_kwargs):
         """Legacy method - use run_stream instead"""
         return self.run_stream(*input_args, **input_kwargs)


### PR DESCRIPTION
## Summary
- Add `get_user_id()`, `get_persistent_memory()`, `get_agent_id()`, `get_entrypoint_tag()`, and `get_extra_params()` getter methods to `RunAgentClient`
- Matches the getter pattern used across Rust, C#, Go, Dart, and TypeScript SDKs
- Attributes remain publicly accessible (idiomatic Python), getters provide cross-SDK API consistency

## Test plan
- [ ] Verify `get_user_id()` returns the configured user ID (or `None`)
- [ ] Verify `get_persistent_memory()` returns the configured flag (defaults to `False`)
- [ ] Verify `get_agent_id()` and `get_entrypoint_tag()` return correct values
- [ ] Verify existing direct attribute access (`client.user_id`, etc.) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new public getter methods to retrieve client configuration and runtime state information: persistent memory user ID, memory settings status, agent ID, entrypoint tag, and optional parameters. These methods provide convenient access to configuration details without affecting existing execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->