### PR TITLE
chore(csharp): bump version to 0.1.49 and fix User-Agent

### DIFF
--- a/runagent-csharp/RunAgent.csproj
+++ b/runagent-csharp/RunAgent.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>RunAgent</PackageId>
-    <Version>0.1.48</Version>
+    <Version>0.1.49</Version>
     <Authors>RunAgent Team</Authors>
     <Company>RunAgent</Company>
     <Description>C# SDK for RunAgent - Secured, reliable AI agent deployment at scale. Run your stack. Let us run your agents.</Description>

--- a/runagent-csharp/src/Client/RestClient.cs
+++ b/runagent-csharp/src/Client/RestClient.cs
@@ -39,7 +39,7 @@ public class RestClient : IDisposable
 
         // Set User-Agent header
         _httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue("RunAgent-CSharp", "0.1.47")
+            new ProductInfoHeaderValue("RunAgent-CSharp", "0.1.49")
         );
 
         // Set Authorization header for remote calls


### PR DESCRIPTION
## Summary
- Bump package version from `0.1.48` to `0.1.49` in `RunAgent.csproj` to align with all other SDKs
- Fix User-Agent header from `0.1.47` to `0.1.49` in `RestClient.cs` (was 2 versions behind)

## Test plan
- [ ] Verify `RunAgent.csproj` shows version `0.1.49`
- [ ] Verify outgoing HTTP requests have `User-Agent: RunAgent-CSharp/0.1.49`
- [ ] Run `dotnet build` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.49

<!-- end of auto-generated comment: release notes by coderabbit.ai -->